### PR TITLE
Auto-close window after focus loss

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -169,6 +169,7 @@ fn build_ui(app: &gtk4::Application) {
     window.add_css_class("waycal");
 
     window.init_layer_shell();
+    window.set_namespace(Some("waycal"));
     window.set_layer(Layer::Top);
     window.set_keyboard_mode(KeyboardMode::OnDemand);
     window.set_anchor(Edge::Top, true);

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,7 @@ use gtk4::prelude::*;
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 const APP_ID: &str = "com.forrestknight.waycal";
-const AUTO_CLOSE_SECS: u32 = 3;
+const AUTO_CLOSE_DELAY: std::time::Duration = std::time::Duration::from_secs(2);
 
 const CSS: &str = r#"
 window.waycal {
@@ -74,7 +74,10 @@ struct ViewDate {
 impl ViewDate {
     fn today() -> Self {
         let now = Local::now().date_naive();
-        Self { year: now.year(), month: now.month() }
+        Self {
+            year: now.year(),
+            month: now.month(),
+        }
     }
 
     fn shift_month(self, delta: i32) -> Self {
@@ -85,7 +88,10 @@ impl ViewDate {
     }
 
     fn shift_year(self, delta: i32) -> Self {
-        Self { year: self.year + delta, month: self.month }
+        Self {
+            year: self.year + delta,
+            month: self.month,
+        }
     }
 }
 
@@ -177,7 +183,9 @@ fn build_ui(app: &gtk4::Application) {
     grid.set_column_spacing(2);
     grid.set_halign(gtk4::Align::Center);
 
-    let footer = gtk4::Label::new(Some("\u{2190}\u{2192} mo   \u{2191}\u{2193} yr   \u{23CE} today   s style"));
+    let footer = gtk4::Label::new(Some(
+        "\u{2190}\u{2192} mo   \u{2191}\u{2193} yr   \u{23CE} today   s style",
+    ));
     footer.add_css_class("waycal-footer");
     footer.set_halign(gtk4::Align::Center);
 
@@ -234,22 +242,28 @@ fn build_ui(app: &gtk4::Application) {
 
     let auto_close: Rc<RefCell<Option<glib::SourceId>>> = Rc::new(RefCell::new(None));
 
-    let focus = gtk4::EventControllerFocus::new();
+    let motion = gtk4::EventControllerMotion::new();
     {
-        let window = window.clone();
         let auto_close = auto_close.clone();
-        focus.connect_leave(move |_| {
-            // Cancel any previous pending timer before scheduling a new one.
+        motion.connect_enter(move |_, _, _| {
             if let Some(id) = auto_close.borrow_mut().take() {
                 id.remove();
             }
-            // Don't schedule if the window is already closing.
+        });
+    }
+    {
+        let window = window.clone();
+        let auto_close = auto_close.clone();
+        motion.connect_leave(move |_| {
+            if let Some(id) = auto_close.borrow_mut().take() {
+                id.remove();
+            }
             if !window.is_visible() {
                 return;
             }
             let window_inner = window.clone();
             let auto_close_inner = auto_close.clone();
-            let id = glib::timeout_add_seconds_local(AUTO_CLOSE_SECS, move || {
+            let id = glib::timeout_add_local(AUTO_CLOSE_DELAY, move || {
                 *auto_close_inner.borrow_mut() = None;
                 window_inner.close();
                 glib::ControlFlow::Break
@@ -257,18 +271,10 @@ fn build_ui(app: &gtk4::Application) {
             *auto_close.borrow_mut() = Some(id);
         });
     }
-    {
-        let auto_close = auto_close.clone();
-        focus.connect_enter(move |_| {
-            if let Some(id) = auto_close.borrow_mut().take() {
-                id.remove();
-            }
-        });
-    }
-    window.add_controller(focus);
+    window.add_controller(motion);
 
-    // Cancel any pending timer when the window is closed (ESC, click-away, etc.)
-    // so we never call close() on an already-destroyed window.
+    // Cancel any pending timer when the window is closed (ESC or otherwise)
+    // so a dangling timeout never calls close() on a destroyed window.
     {
         let auto_close = auto_close.clone();
         window.connect_close_request(move |_| {
@@ -279,13 +285,12 @@ fn build_ui(app: &gtk4::Application) {
         });
     }
 
-    // Fallback initial timer: with KeyboardMode::OnDemand, Hyprland does not grant
-    // keyboard focus automatically, so connect_leave may never fire. This ensures
-    // the window still closes if the user never interacts with it.
+    // Start an initial timer for when the window opens with the pointer already
+    // outside it — motion.connect_leave won't fire in that case.
     {
         let window_inner = window.clone();
         let auto_close_inner = auto_close.clone();
-        let id = glib::timeout_add_seconds_local(AUTO_CLOSE_SECS, move || {
+        let id = glib::timeout_add_local(AUTO_CLOSE_DELAY, move || {
             *auto_close_inner.borrow_mut() = None;
             window_inner.close();
             glib::ControlFlow::Break

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,6 +9,7 @@ use gtk4::prelude::*;
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 const APP_ID: &str = "com.forrestknight.waycal";
+const AUTO_CLOSE_SECS: u32 = 3;
 
 const CSS: &str = r#"
 window.waycal {
@@ -230,6 +231,67 @@ fn build_ui(app: &gtk4::Application) {
         });
     }
     window.add_controller(key);
+
+    let auto_close: Rc<RefCell<Option<glib::SourceId>>> = Rc::new(RefCell::new(None));
+
+    let focus = gtk4::EventControllerFocus::new();
+    {
+        let window = window.clone();
+        let auto_close = auto_close.clone();
+        focus.connect_leave(move |_| {
+            // Cancel any previous pending timer before scheduling a new one.
+            if let Some(id) = auto_close.borrow_mut().take() {
+                id.remove();
+            }
+            // Don't schedule if the window is already closing.
+            if !window.is_visible() {
+                return;
+            }
+            let window_inner = window.clone();
+            let auto_close_inner = auto_close.clone();
+            let id = glib::timeout_add_seconds_local(AUTO_CLOSE_SECS, move || {
+                *auto_close_inner.borrow_mut() = None;
+                window_inner.close();
+                glib::ControlFlow::Break
+            });
+            *auto_close.borrow_mut() = Some(id);
+        });
+    }
+    {
+        let auto_close = auto_close.clone();
+        focus.connect_enter(move |_| {
+            if let Some(id) = auto_close.borrow_mut().take() {
+                id.remove();
+            }
+        });
+    }
+    window.add_controller(focus);
+
+    // Cancel any pending timer when the window is closed (ESC, click-away, etc.)
+    // so we never call close() on an already-destroyed window.
+    {
+        let auto_close = auto_close.clone();
+        window.connect_close_request(move |_| {
+            if let Some(id) = auto_close.borrow_mut().take() {
+                id.remove();
+            }
+            glib::Propagation::Proceed
+        });
+    }
+
+    // Fallback initial timer: with KeyboardMode::OnDemand, Hyprland does not grant
+    // keyboard focus automatically, so connect_leave may never fire. This ensures
+    // the window still closes if the user never interacts with it.
+    {
+        let window_inner = window.clone();
+        let auto_close_inner = auto_close.clone();
+        let id = glib::timeout_add_seconds_local(AUTO_CLOSE_SECS, move || {
+            *auto_close_inner.borrow_mut() = None;
+            window_inner.close();
+            glib::ControlFlow::Break
+        });
+        *auto_close.borrow_mut() = Some(id);
+    }
 
     window.present();
 }


### PR DESCRIPTION
## What changed

Waycal now automatically closes itself **2 seconds after the cursor leaves the window** (configurable via `AUTO_CLOSE_DELAY`). This makes it feel like a proper ephemeral popup — open it, glance at the date, move your mouse away, and it disappears on its own.

A GTK layer-shell **namespace** (`waycal`) is also set on the window, so compositors can target it with precise layerrules (e.g. `layerrule = blur on, ignore_alpha 0.5 , match:namespace waycal`).

## How it works

- **`EventControllerMotion`** — tracks pointer enter/leave on the window surface. No input is grabbed or consumed; this is purely passive observation.
- **`motion.connect_enter`** — cancels the pending timer when the cursor moves over the window.
- **`motion.connect_leave`** — starts a 2-second GLib timeout when the cursor leaves. Uses `timeout_add_local` (millisecond-granularity) instead of `timeout_add_seconds_local`, which has up to ~1 second of coalescing slop by design.
- **Fallback initial timer** — started immediately on `window.present()` to handle the case where the cursor is already outside the window when it opens (motion leave won't fire in that case).
- **`connect_close_request`** — cancels any pending timer when the window is closed via ESC or any other path, so a dangling timeout never calls `close()` on an already-destroyed window.
- **`set_namespace("waycal")`** — assigns the layer-shell namespace so Hyprland and other compositors can match the window with layerrules.

## What doesn't change

- `KeyboardMode::OnDemand` is untouched — the window never steals keyboard focus from the user.
- No threads, no polling. Everything runs on the GLib main loop.
- ESC still works exactly as before.