### PR TITLE
Use Omarchy theme colors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -92,10 +92,8 @@ fn main() -> glib::ExitCode {
 }
 
 fn load_css() {
-    let palette = theme::Palette::from_omarchy();
-    let css = theme::build_css(&palette);
     let provider = gtk4::CssProvider::new();
-    provider.load_from_string(&css);
+    provider.load_from_string(&theme::build_css(&theme::Palette::from_omarchy()));
     if let Some(display) = gdk::Display::default() {
         gtk4::style_context_add_provider_for_display(
             &display,
@@ -103,6 +101,7 @@ fn load_css() {
             gtk4::STYLE_PROVIDER_PRIORITY_APPLICATION,
         );
     }
+    theme::watch_and_reload(provider);
 }
 
 fn build_ui(app: &gtk4::Application) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod theme;
+
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -9,60 +11,6 @@ use gtk4::prelude::*;
 use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 const APP_ID: &str = "com.forrestknight.waycal";
-
-const CSS: &str = r#"
-window.waycal {
-    background: transparent;
-}
-.waycal-root {
-    background-color: #1a2125;
-    border: 2px solid #8FBC8F;
-    border-radius: 0;
-    padding: 14px 18px;
-    color: #c9d1d9;
-    font-family: "CaskaydiaMono Nerd Font", monospace;
-    font-size: 13px;
-    min-width: 260px;
-}
-.waycal-root.rounded {
-    background-color: rgba(26, 33, 37, 0.96);
-    border: 2px solid transparent;
-    border-radius: 16px;
-}
-.waycal-header {
-    font-weight: bold;
-    font-size: 15px;
-    padding-bottom: 6px;
-}
-.waycal-weekday {
-    color: #8FBC8F;
-    font-weight: bold;
-    padding: 2px 6px;
-}
-.waycal-day {
-    padding: 4px 7px;
-    min-width: 18px;
-}
-.waycal-day.dim {
-    opacity: 0.3;
-}
-.waycal-day.today {
-    background-color: #8FBC8F;
-    color: #1a2125;
-    border-radius: 0;
-    font-weight: bold;
-}
-.waycal-root.rounded .waycal-day.today {
-    border-radius: 8px;
-}
-.waycal-footer {
-    color: #6a7a71;
-    font-size: 10px;
-    padding-top: 8px;
-    margin-top: 6px;
-    border-top: 1px solid rgba(143, 188, 143, 0.18);
-}
-"#;
 
 #[derive(Clone, Copy)]
 struct ViewDate {
@@ -144,8 +92,10 @@ fn main() -> glib::ExitCode {
 }
 
 fn load_css() {
+    let palette = theme::Palette::from_omarchy();
+    let css = theme::build_css(&palette);
     let provider = gtk4::CssProvider::new();
-    provider.load_from_string(CSS);
+    provider.load_from_string(&css);
     if let Some(display) = gdk::Display::default() {
         gtk4::style_context_add_provider_for_display(
             &display,

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,5 +1,9 @@
 use std::path::PathBuf;
 
+use gtk4::CssProvider;
+use gtk4::gio;
+use gtk4::prelude::*;
+
 pub struct Palette {
     pub background: String,
     pub background_rgba: String,
@@ -135,6 +139,30 @@ window.waycal {{
 fn omarchy_colors_path() -> Option<PathBuf> {
     let home = std::env::var_os("HOME")?;
     Some(PathBuf::from(home).join(".config/omarchy/current/theme/colors.toml"))
+}
+
+fn omarchy_theme_name_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".config/omarchy/current/theme.name"))
+}
+
+pub fn watch_and_reload(provider: CssProvider) {
+    let Some(path) = omarchy_theme_name_path() else {
+        return;
+    };
+    let file = gio::File::for_path(&path);
+    let Ok(monitor) = file.monitor_file(gio::FileMonitorFlags::NONE, gio::Cancellable::NONE) else {
+        return;
+    };
+    monitor.connect_changed(move |_, _, _, event| {
+        if matches!(
+            event,
+            gio::FileMonitorEvent::ChangesDoneHint | gio::FileMonitorEvent::Created
+        ) {
+            provider.load_from_string(&build_css(&Palette::from_omarchy()));
+        }
+    });
+    Box::leak(Box::new(monitor));
 }
 
 fn parse_toml_string(line: &str) -> Option<(&str, String)> {

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -1,0 +1,158 @@
+use std::path::PathBuf;
+
+pub struct Palette {
+    pub background: String,
+    pub background_rgba: String,
+    pub foreground: String,
+    pub accent: String,
+    pub accent_alpha: String,
+    pub muted: String,
+}
+
+impl Palette {
+    fn fallback() -> Self {
+        Self {
+            background: "#1a2125".into(),
+            background_rgba: "rgba(26, 33, 37, 0.96)".into(),
+            foreground: "#c9d1d9".into(),
+            accent: "#8FBC8F".into(),
+            accent_alpha: "rgba(143, 188, 143, 0.18)".into(),
+            muted: "#6a7a71".into(),
+        }
+    }
+
+    pub fn from_omarchy() -> Self {
+        let Some(path) = omarchy_colors_path() else {
+            return Self::fallback();
+        };
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            return Self::fallback();
+        };
+
+        let mut fb = Self::fallback();
+        let mut background = None;
+        let mut foreground = None;
+        let mut accent = None;
+        let mut muted = None;
+
+        for line in text.lines() {
+            let Some((key, value)) = parse_toml_string(line) else {
+                continue;
+            };
+            match key {
+                "background" => background = Some(value),
+                "foreground" => foreground = Some(value),
+                "accent" => accent = Some(value),
+                "color8" => muted = Some(value),
+                _ => {}
+            }
+        }
+
+        if let Some(v) = background {
+            fb.background_rgba =
+                hex_to_rgba(&v, 0.96).unwrap_or_else(|| fb.background_rgba.clone());
+            fb.background = v;
+        }
+        if let Some(v) = foreground {
+            fb.foreground = v;
+        }
+        if let Some(v) = accent {
+            fb.accent_alpha =
+                hex_to_rgba(&v, 0.18).unwrap_or_else(|| fb.accent_alpha.clone());
+            fb.accent = v;
+        }
+        if let Some(v) = muted {
+            fb.muted = v;
+        }
+        fb
+    }
+}
+
+pub fn build_css(p: &Palette) -> String {
+    format!(
+        r#"
+window.waycal {{
+    background: transparent;
+}}
+.waycal-root {{
+    background-color: {bg};
+    border: 2px solid {accent};
+    border-radius: 0;
+    padding: 14px 18px;
+    color: {fg};
+    font-family: "CaskaydiaMono Nerd Font", monospace;
+    font-size: 13px;
+    min-width: 260px;
+}}
+.waycal-root.rounded {{
+    background-color: {bg_rgba};
+    border: 2px solid transparent;
+    border-radius: 16px;
+}}
+.waycal-header {{
+    font-weight: bold;
+    font-size: 15px;
+    padding-bottom: 6px;
+}}
+.waycal-weekday {{
+    color: {accent};
+    font-weight: bold;
+    padding: 2px 6px;
+}}
+.waycal-day {{
+    padding: 4px 7px;
+    min-width: 18px;
+}}
+.waycal-day.dim {{
+    opacity: 0.3;
+}}
+.waycal-day.today {{
+    background-color: {accent};
+    color: {bg};
+    border-radius: 0;
+    font-weight: bold;
+}}
+.waycal-root.rounded .waycal-day.today {{
+    border-radius: 8px;
+}}
+.waycal-footer {{
+    color: {muted};
+    font-size: 10px;
+    padding-top: 8px;
+    margin-top: 6px;
+    border-top: 1px solid {accent_alpha};
+}}
+"#,
+        bg = p.background,
+        bg_rgba = p.background_rgba,
+        fg = p.foreground,
+        accent = p.accent,
+        accent_alpha = p.accent_alpha,
+        muted = p.muted,
+    )
+}
+
+fn omarchy_colors_path() -> Option<PathBuf> {
+    let home = std::env::var_os("HOME")?;
+    Some(PathBuf::from(home).join(".config/omarchy/current/theme/colors.toml"))
+}
+
+fn parse_toml_string(line: &str) -> Option<(&str, String)> {
+    let (key, rest) = line.trim().split_once('=')?;
+    let key = key.trim();
+    let rest = rest.trim_start();
+    let rest = rest.strip_prefix('"')?;
+    let end = rest.find('"')?;
+    Some((key, rest[..end].to_string()))
+}
+
+fn hex_to_rgba(hex: &str, alpha: f32) -> Option<String> {
+    let h = hex.strip_prefix('#')?;
+    if h.len() != 6 {
+        return None;
+    }
+    let r = u8::from_str_radix(&h[0..2], 16).ok()?;
+    let g = u8::from_str_radix(&h[2..4], 16).ok()?;
+    let b = u8::from_str_radix(&h[4..6], 16).ok()?;
+    Some(format!("rgba({r}, {g}, {b}, {alpha})"))
+}


### PR DESCRIPTION
## Summary
Make waycal pick up the active Omarchy theme instead of the hard-coded green palette.

## What it does and how

- Reads `~/.config/omarchy/current/theme/colors.toml` at startup and maps `accent`, `background`, `foreground`, and `color8` into the window, border, weekday, today-cell, and footer styles.

- Watches `~/.config/omarchy/current/theme.name` with `gio::FileMonitor`; on every `omarchy-theme-set`, the open popup re-reads the palette and re-applies CSS without needing to be closed.

- Falls back to the original hardcoded colors when the Omarchy files aren't present, so non-Omarchy users are unaffected.


Demo video:

https://github.com/user-attachments/assets/9f1309e0-702f-4898-9993-4a28ca336efc

