### PR TITLE
Ignore makepkg build artifacts in packaging/aur

### DIFF
--- a/packaging/aur/.gitignore
+++ b/packaging/aur/.gitignore
@@ -1,0 +1,5 @@
+# makepkg build artifacts
+pkg/
+src/
+*.tar.gz
+*.pkg.tar.*


### PR DESCRIPTION
## Summary
Adds `packaging/aur/.gitignore` so a local `makepkg` run inside that directory doesn't leave a dirty working tree. Ignores the standard makepkg outputs: `pkg/`, `src/`, the source tarball (`*.tar.gz`), and the built package (`*.pkg.tar.*`).

## Test plan
- [x] `makepkg -sf` in `packaging/aur/`, then `git status` reports clean
- [x] Tracked files (`PKGBUILD`, `.SRCINFO`) are unaffected by the patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)