### PR TITLE
Add system/omarchy color theming

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -10,59 +10,103 @@ use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
 
 const APP_ID: &str = "com.forrestknight.waycal";
 
-const CSS: &str = r#"
-window.waycal {
-    background: transparent;
+struct ThemeColors {
+    bg: String,
+    fg: String,
+    accent: String,
+    on_accent: String,
 }
-.waycal-root {
-    background-color: @theme_bg_color;
-    border: 2px solid @borders;
+
+fn load_theme_colors() -> Option<ThemeColors> {
+    let base = std::env::var_os("XDG_CONFIG_HOME")
+        .map(PathBuf::from)
+        .or_else(|| std::env::var_os("HOME").map(|h| PathBuf::from(h).join(".config")))?;
+    let path = base.join("omarchy/current/theme/colors.toml");
+    let content = std::fs::read_to_string(path).ok()?;
+    let mut bg = None;
+    let mut fg = None;
+    let mut accent = None;
+    for line in content.lines() {
+        let Some((k, v)) = line.split_once('=') else { continue };
+        let key = k.trim();
+        let val = v.trim().trim_matches('"').to_string();
+        match key {
+            "background" => bg = Some(val),
+            "foreground" => fg = Some(val),
+            "accent" => accent = Some(val),
+            _ => {}
+        }
+    }
+    let bg = bg?;
+    Some(ThemeColors { on_accent: bg.clone(), bg, fg: fg?, accent: accent? })
+}
+
+fn build_css() -> String {
+    let (bg, fg, accent, on_accent) = match load_theme_colors() {
+        Some(c) => (c.bg, c.fg, c.accent, c.on_accent),
+        None => (
+            "@theme_bg_color".into(),
+            "@theme_fg_color".into(),
+            "@theme_selected_bg_color".into(),
+            "@theme_selected_fg_color".into(),
+        ),
+    };
+    format!(
+        r#"
+window.waycal {{
+    background: transparent;
+}}
+.waycal-root {{
+    background-color: {bg};
+    border: 2px solid {accent};
     border-radius: 0;
     padding: 14px 18px;
-    color: @theme_fg_color;
+    color: {fg};
     font-family: "CaskaydiaMono Nerd Font", monospace;
     font-size: 13px;
     min-width: 260px;
-}
-.waycal-root.rounded {
-    background-color: alpha(@theme_bg_color, 0.96);
+}}
+.waycal-root.rounded {{
+    background-color: alpha({bg}, 0.96);
     border: 2px solid transparent;
     border-radius: 16px;
-}
-.waycal-header {
+}}
+.waycal-header {{
     font-weight: bold;
     font-size: 15px;
     padding-bottom: 6px;
-}
-.waycal-weekday {
-    color: @theme_selected_bg_color;
+}}
+.waycal-weekday {{
+    color: {accent};
     font-weight: bold;
     padding: 2px 6px;
-}
-.waycal-day {
+}}
+.waycal-day {{
     padding: 4px 7px;
     min-width: 18px;
-}
-.waycal-day.dim {
+}}
+.waycal-day.dim {{
     opacity: 0.3;
-}
-.waycal-day.today {
-    background-color: @theme_selected_bg_color;
-    color: @theme_selected_fg_color;
+}}
+.waycal-day.today {{
+    background-color: {accent};
+    color: {on_accent};
     border-radius: 0;
     font-weight: bold;
-}
-.waycal-root.rounded .waycal-day.today {
+}}
+.waycal-root.rounded .waycal-day.today {{
     border-radius: 8px;
-}
-.waycal-footer {
-    color: alpha(@theme_fg_color, 0.55);
+}}
+.waycal-footer {{
+    color: alpha({fg}, 0.55);
     font-size: 10px;
     padding-top: 8px;
     margin-top: 6px;
-    border-top: 1px solid @borders;
+    border-top: 1px solid alpha({accent}, 0.25);
+}}
+"#
+    )
 }
-"#;
 
 #[derive(Clone, Copy)]
 struct ViewDate {
@@ -145,7 +189,7 @@ fn main() -> glib::ExitCode {
 
 fn load_css() {
     let provider = gtk4::CssProvider::new();
-    provider.load_from_string(CSS);
+    provider.load_from_string(&build_css());
     if let Some(display) = gdk::Display::default() {
         gtk4::style_context_add_provider_for_display(
             &display,

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,17 +15,17 @@ window.waycal {
     background: transparent;
 }
 .waycal-root {
-    background-color: #1a2125;
-    border: 2px solid #8FBC8F;
+    background-color: @theme_bg_color;
+    border: 2px solid @borders;
     border-radius: 0;
     padding: 14px 18px;
-    color: #c9d1d9;
+    color: @theme_fg_color;
     font-family: "CaskaydiaMono Nerd Font", monospace;
     font-size: 13px;
     min-width: 260px;
 }
 .waycal-root.rounded {
-    background-color: rgba(26, 33, 37, 0.96);
+    background-color: alpha(@theme_bg_color, 0.96);
     border: 2px solid transparent;
     border-radius: 16px;
 }
@@ -35,7 +35,7 @@ window.waycal {
     padding-bottom: 6px;
 }
 .waycal-weekday {
-    color: #8FBC8F;
+    color: @theme_selected_bg_color;
     font-weight: bold;
     padding: 2px 6px;
 }
@@ -47,8 +47,8 @@ window.waycal {
     opacity: 0.3;
 }
 .waycal-day.today {
-    background-color: #8FBC8F;
-    color: #1a2125;
+    background-color: @theme_selected_bg_color;
+    color: @theme_selected_fg_color;
     border-radius: 0;
     font-weight: bold;
 }
@@ -56,11 +56,11 @@ window.waycal {
     border-radius: 8px;
 }
 .waycal-footer {
-    color: #6a7a71;
+    color: alpha(@theme_fg_color, 0.55);
     font-size: 10px;
     padding-top: 8px;
     margin-top: 6px;
-    border-top: 1px solid rgba(143, 188, 143, 0.18);
+    border-top: 1px solid @borders;
 }
 "#;
 


### PR DESCRIPTION
## Summary
Replaces the hardcoded slate + DarkSeaGreen palette with theme-aware colors so the popup blends with the rest of the desktop instead of standing out from the user's terminal, waybar, etc.

## Motivation
The CSS hardcoded `#1a2125` background, `#8FBC8F` accent, and `#c9d1d9` text. On any system running a different theme — and especially for omarchy users running Everforest, Tokyo Night, Catppuccin, etc. — the calendar popup clashed with everything else on the desktop.

## Changes
- Read `background`, `foreground`, and `accent` from `~/.config/omarchy/current/theme/colors.toml` when present (omarchy publishes the active theme's palette there).
- Fall back to GTK named colors (`@theme_bg_color`, `@theme_fg_color`, `@theme_selected_bg_color`, `@theme_selected_fg_color`) so non-omarchy users still get a themed popup rather than the old hardcoded values.
- Build the CSS as a `format!` template so the resolved colors substitute into both branches.
- No new dependencies — the TOML file is parsed inline (simple `key = "value"` lines).

## Testing
- `cargo build` clean.
- Verified visually under omarchy with Everforest Dark: bg, fg, border, weekday headers, today highlight, and footer divider now all match the rest of the desktop.
- Verified the GTK fallback by temporarily renaming `colors.toml` — popup falls back to GTK theme defaults instead of erroring.

## Notes
- Colors are read once at startup. waycal is a popup that opens and closes per invocation, so it picks up theme switches on the next launch. No live file-watcher.
- The `accent` token from omarchy drives borders, weekday labels, today highlight background, and the footer divider — preserving the original design's "background + foreground + single accent" structure.