### PR TITLE
Add option to set custom location

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,14 @@ cargo build --release
 install -Dm755 target/release/waycal ~/.local/bin/waycal
 ```
 
+## CLI options
+
+- `--position <value>` — where the popup anchors on screen. One of `top-left`, `top` (default), `top-right`, `left`, `center`, `right`, `bottom-left`, `bottom`, `bottom-right`. An unrecognized value prints a warning and falls back to `top`.
+
+```sh
+waycal --position bottom-right
+```
+
 ## Waybar integration
 
 Add a custom module to your `~/.config/waybar/config.jsonc`:

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -1,0 +1,93 @@
+use std::cell::Cell;
+use std::rc::Rc;
+
+use gtk4::glib;
+use gtk4::prelude::*;
+use gtk4_layer_shell::Edge;
+
+const MARGIN: i32 = 8;
+
+const VALID_VALUES: &str =
+    "top-left, top, top-right, left, center, right, bottom-left, bottom, bottom-right";
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct Position {
+    pub top: bool,
+    pub bottom: bool,
+    pub left: bool,
+    pub right: bool,
+}
+
+impl Position {
+    pub const DEFAULT: Position = Position { top: true, bottom: false, left: false, right: false };
+
+    fn parse(s: &str) -> Option<Position> {
+        let (top, bottom, left, right) = match s {
+            "top-left" => (true, false, true, false),
+            "top" => (true, false, false, false),
+            "top-right" => (true, false, false, true),
+            "left" => (false, false, true, false),
+            "center" => (false, false, false, false),
+            "right" => (false, false, false, true),
+            "bottom-left" => (false, true, true, false),
+            "bottom" => (false, true, false, false),
+            "bottom-right" => (false, true, false, true),
+            _ => return None,
+        };
+        Some(Position { top, bottom, left, right })
+    }
+
+    pub fn anchors(&self) -> [(Edge, bool); 4] {
+        [
+            (Edge::Top, self.top),
+            (Edge::Bottom, self.bottom),
+            (Edge::Left, self.left),
+            (Edge::Right, self.right),
+        ]
+    }
+
+    pub fn margin(&self, edge: Edge) -> i32 {
+        // Preserve the original flush-with-bar look for the default top anchor.
+        if *self == Position::DEFAULT && edge == Edge::Top {
+            return 0;
+        }
+        match edge {
+            Edge::Top if self.top => MARGIN,
+            Edge::Bottom if self.bottom => MARGIN,
+            Edge::Left if self.left => MARGIN,
+            Edge::Right if self.right => MARGIN,
+            _ => 0,
+        }
+    }
+}
+
+/// Registers `--position` with GLib's option parser (so it shows up in
+/// `--help`) and returns a cell that holds the parsed value once the
+/// application's `handle-local-options` signal has fired.
+pub fn install(app: &gtk4::Application) -> Rc<Cell<Position>> {
+    app.add_main_option(
+        "position",
+        glib::Char::from(0u8),
+        glib::OptionFlags::NONE,
+        glib::OptionArg::String,
+        &format!("Where the popup anchors on screen: {VALID_VALUES}"),
+        Some("VALUE"),
+    );
+
+    let position = Rc::new(Cell::new(Position::DEFAULT));
+    {
+        let position = position.clone();
+        app.connect_handle_local_options(move |_, options| {
+            if let Some(value) = options.lookup::<String>("position").ok().flatten() {
+                match Position::parse(&value) {
+                    Some(pos) => position.set(pos),
+                    None => eprintln!(
+                        "waycal: invalid --position value '{value}', expected one of: {VALID_VALUES}. Falling back to 'top'."
+                    ),
+                }
+            }
+            -1
+        });
+    }
+    position
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,3 +1,5 @@
+mod cli;
+
 use std::cell::RefCell;
 use std::path::PathBuf;
 use std::rc::Rc;
@@ -6,7 +8,9 @@ use chrono::{Datelike, Local, NaiveDate};
 use gtk4::gdk;
 use gtk4::glib;
 use gtk4::prelude::*;
-use gtk4_layer_shell::{Edge, KeyboardMode, Layer, LayerShell};
+use gtk4_layer_shell::{KeyboardMode, Layer, LayerShell};
+
+use cli::Position;
 
 const APP_ID: &str = "com.forrestknight.waycal";
 
@@ -138,8 +142,9 @@ fn month_name(m: u32) -> &'static str {
 
 fn main() -> glib::ExitCode {
     let app = gtk4::Application::builder().application_id(APP_ID).build();
+    let position = cli::install(&app);
     app.connect_startup(|_| load_css());
-    app.connect_activate(build_ui);
+    app.connect_activate(move |app| build_ui(app, position.get()));
     app.run()
 }
 
@@ -155,7 +160,7 @@ fn load_css() {
     }
 }
 
-fn build_ui(app: &gtk4::Application) {
+fn build_ui(app: &gtk4::Application, position: Position) {
     let window = gtk4::ApplicationWindow::new(app);
     window.set_decorated(false);
     window.set_resizable(false);
@@ -163,9 +168,11 @@ fn build_ui(app: &gtk4::Application) {
 
     window.init_layer_shell();
     window.set_layer(Layer::Top);
-    window.set_keyboard_mode(KeyboardMode::OnDemand);
-    window.set_anchor(Edge::Top, true);
-    window.set_margin(Edge::Top, 0);
+    window.set_keyboard_mode(KeyboardMode::Exclusive);
+    for (edge, anchored) in position.anchors() {
+        window.set_anchor(edge, anchored);
+        window.set_margin(edge, position.margin(edge));
+    }
 
     let header = gtk4::Label::new(None);
     header.add_css_class("waycal-header");


### PR DESCRIPTION
I actually have two changes here - 
1. A crude commandline arg `--position`
2. Keyboard focus set to grab exclusivly since in my swaywm config I realized only first keystroke registers

I had made these two for personal use so didn't commit it separately but thought you might be interested in it.

The CLI is crude as in, I haven't created a `Config` struct that sits between args and App. The `position` is directly exposed as the singular config. The idea is to create `Config` if we add more cli args later. It's a trivial change to make at the point.